### PR TITLE
Agent list de-duplication, return-codes

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,9 +15,15 @@ Add the following to automatically choose the first agent
 ssh-find-agent -a
 if [ -z "$SSH_AUTH_SOCK" ]
 then
-   eval $(ssh_agent) > /dev/null
+   eval $(ssh-agent) > /dev/null
    ssh-add -l >/dev/null || alias ssh='ssh-add -l >/dev/null || ssh-add && unalias ssh; ssh'
 fi
+```
+
+... or, as `ssh-find-agent` with `-a` or `-c` returns non-zero if it cannot find a live-agent, simply:
+
+```bash
+ssh-find-agent -a || eval $(ssh-agent) > /dev/null
 ```
 
 To choose the agent manually run

--- a/ssh-find-agent.sh
+++ b/ssh-find-agent.sh
@@ -153,7 +153,7 @@ set_ssh_agent_socket() {
 
 		if [ -z "$_LIVE_AGENT_LIST" ] ; then
 			echo "No agents found"
-			return
+			return 1
 		fi
 
 		echo -n "Choose (1-${#_LIVE_AGENT_SOCK_LIST[@]})? "
@@ -163,25 +163,34 @@ set_ssh_agent_socket() {
 			n=$((choice-1))
 			if [ -z "${_LIVE_AGENT_SOCK_LIST[$n]}" ] ; then
 				echo "Invalid choice"
-				return
+				return 1
 			fi
 			echo "Setting export SSH_AUTH_SOCK=${_LIVE_AGENT_SOCK_LIST[$n]}"
 			export SSH_AUTH_SOCK=${_LIVE_AGENT_SOCK_LIST[$n]}
 		fi
 	else
 		# Choose the first available
-			export SSH_AUTH_SOCK=$(find_all_agent_sockets|tail -n 1|awk -F: '{print $1}')
+		SOCK=$(find_all_agent_sockets|tail -n 1|awk -F: '{print $1}')
+		if [ -z "$SOCK" ] ; then
+			return 1
+		fi
+		export SSH_AUTH_SOCK=$SOCK
 	fi
+
+	return 0
 }
 
 ssh-find-agent() {
 	if [ "$1" = "-c" -o "$1" = "--choose" ]
 	then
 		set_ssh_agent_socket -c
+		return $?
 	elif [ "$1" = "-a" -o "$1" = "--auto" ]
 	then
-		set_ssh_agent_socket 
+		set_ssh_agent_socket
+		return $?
 	else
 		find_all_agent_sockets -i
+		return 0
 	fi
 }

--- a/ssh-find-agent.sh
+++ b/ssh-find-agent.sh
@@ -129,7 +129,7 @@ find_all_agent_sockets() {
 	find_live_gnome_keyring_agents
 	find_live_osx_keychain_agents
 	_debug_print "$_LIVE_AGENT_LIST"
-	_LIVE_AGENT_LIST=$(echo $_LIVE_AGENT_LIST | tr ' ' '\n' | sort -n -t: -k 2 -k 1)
+	_LIVE_AGENT_LIST=$(echo $_LIVE_AGENT_LIST | tr ' ' '\n' | sort -u -n -t: -k 2 -k 1)
 	_LIVE_AGENT_SOCK_LIST=()
 	if [[ $_SHOW_IDENTITY -gt 0 ]]
 	then


### PR DESCRIPTION
* Added -u to sort to de-duplicate discovered agent sockets. Fixed #14.
* Set a non-zero return-code if setting agent with -a or -c finds no agents, allowing `ssh-find-agent -a || eval $(ssh-agent) > /dev/null`
* Don't zero current SSH_AUTH_SOCK if no live agents found/selected when using -a.
* ssh_agent -> ssh-agent in README.md.