### PR TITLE
add authorized_keys comment support

### DIFF
--- a/ssh-find-agent.sh
+++ b/ssh-find-agent.sh
@@ -47,6 +47,9 @@ find_all_gnome_keyring_agent_sockets() {
 	_debug_print "$_GNOME_KEYRING_AGENT_SOCKETS"
 }
 
+# This function overlaps with find_all_ssh_agent_sockets on Centos
+# (this makes it list entries twice)
+# Maybe we should add a quick check to see if we are on osx
 find_all_osx_keychain_agent_sockets() {
 	[[ -n "$TMPDIR" ]] || TMPDIR=/tmp
 	_OSX_KEYCHAIN_AGENT_SOCKETS=`find $TMPDIR/ -type s -regex '.*/ssh-.*/agent..*$' 2> /dev/null`
@@ -120,14 +123,15 @@ find_all_agent_sockets() {
 		_SHOW_IDENTITY=1
 	fi
 	_LIVE_AGENT_LIST=
-	find_all_ssh_agent_sockets
-	find_all_gpg_agent_sockets
-	find_all_gnome_keyring_agent_sockets
-	find_all_osx_keychain_agent_sockets
 	find_live_ssh_agents
 	find_live_gpg_agents
 	find_live_gnome_keyring_agents
-	find_live_osx_keychain_agents
+  # We don't often remote into osx, and we only want live sockets
+  #find_live_osx_keychain_agents
+	#find_all_ssh_agent_sockets
+	#find_all_gpg_agent_sockets
+	#find_all_gnome_keyring_agent_sockets
+	#find_all_osx_keychain_agent_sockets
 	_debug_print "$_LIVE_AGENT_LIST"
 	_LIVE_AGENT_LIST=$(echo $_LIVE_AGENT_LIST | tr ' ' '\n' | sort -n -t: -k 2 -k 1)
 	_LIVE_AGENT_SOCK_LIST=()

--- a/ssh-find-agent.sh
+++ b/ssh-find-agent.sh
@@ -3,17 +3,17 @@
 # Released under one of the versions of the MIT License.
 #
 # Copyright (C) 2011 by Wayne Walker <wwalker@solid-constructs.com>
-# 
+#
 # Permission is hereby granted, free of charge, to any person obtaining a copy
 # of this software and associated documentation files (the "Software"), to deal
 # in the Software without restriction, including without limitation the rights
 # to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
 # copies of the Software, and to permit persons to whom the Software is
 # furnished to do so, subject to the following conditions:
-# 
+#
 # The above copyright notice and this permission notice shall be included in
 # all copies or substantial portions of the Software.
-# 
+#
 # THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
 # IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
 # FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
@@ -135,7 +135,7 @@ find_all_agent_sockets() {
 	then
 		i=0
 		for a in $_LIVE_AGENT_LIST ; do
-			sock=${a/:*/} 
+			sock=${a/:*/}
 			_LIVE_AGENT_SOCK_LIST[$i]=$sock
 			akeys=$(SSH_AUTH_SOCK=$sock ssh-add -l) 
 			printf "%i) %s\n\t%s\n" $((i+1)) "$a" "$akeys"
@@ -180,7 +180,7 @@ ssh-find-agent() {
 		set_ssh_agent_socket -c
 	elif [ "$1" = "-a" -o "$1" = "--auto" ]
 	then
-		set_ssh_agent_socket 
+		set_ssh_agent_socket
 	else
 		find_all_agent_sockets -i
 	fi


### PR DESCRIPTION
Our use case is multiple people forwarding keys to one pair box.

When selecting a forwarded agent to pull a key from, it's nice to know who it belongs to.

```
$ . ssh-find-agent.sh ; ssh-find-agent  -c
1) /tmp/ssh-GJXISEnqyj/agent.8935:1 forwards /home/hh/.ssh/id_rsa-4096-20090605-ccc
        4096 1b:a8:6e:48:d5:de:83:7e:1e:58:80:33:a6:03:0b:c6  hh (RSA)
2) /tmp/ssh-Sbx1NNrWl7Q5/agent.3092:1 forwards .ssh/id_rsa
        2048 c7:fc:d3:77:dd:d9:91:74:9b:6d:7a:83:fc:50:a4:33  Emilie (RSA)
Choose (1-2)? 1
Setting export SSH_AUTH_SOCK=/tmp/ssh-GJXISEnqyj/agent.8935
```

Add fingerprint functions to display authorized_keys comments when selecting an agent.

```
$ fingerprints ~/.ssh/authorized_keys 
4096 96:17:9c:9c:97:bf:14:dc:ec:a1:fe:8e:7f:e1:34:1e  taylor@codecafe.com (RSA)
4096 1b:a8:6e:48:d5:de:83:7e:1e:58:80:33:a6:03:0b:c6  hh (RSA)
2048 8e:d4:32:ea:d3:41:e1:c3:44:16:8a:c9:d2:2c:69:0d  Emilie (RSA)
4096 68:75:63:72:40:00:3d:7f:53:72:3a:67:95:72:9e:fa  Emilie (RSA)
2048 c7:fc:d3:77:dd:d9:91:74:9b:6d:7a:83:fc:50:a4:33  Emilie (RSA)
4096 82:11:95:e6:a6:7e:18:70:fc:d8:61:ae:3c:f7:0c:10  cardno:000604171938 (RSA)
2048 3d:80:df:0b:bc:16:c8:f4:7a:c7:28:76:e6:1b:d6:f1  chris@cardno:000500002C10 (RSA)
2048 55:87:de:f8:c3:40:9f:42:ac:aa:65:cc:fc:fe:cc:85  wavell.watson@gmail.com (RSA)
```

Also fixed an issue where the find osx socket functions caught the same socket twice on centos.
