### PR TITLE
Leverage TMPDIR on all platforms

### DIFF
--- a/ssh-find-agent.sh
+++ b/ssh-find-agent.sh
@@ -28,6 +28,9 @@ _LIVE_AGENT_LIST=""
 declare -a _LIVE_AGENT_SOCK_LIST
 _LIVE_AGENT_SOCK_LIST=()
 
+# temp dir. Defaults to /tmp
+TMPDIR="${TMPDIR:-/tmp}"
+
 _debug_print() {
 	if [[ $_DEBUG -gt 0 ]]
 	then
@@ -36,23 +39,22 @@ _debug_print() {
 }
 
 find_all_ssh_agent_sockets() {
-	_SSH_AGENT_SOCKETS=$( find /tmp/ -type s -name agent.\* 2> /dev/null | grep '/tmp/ssh-.*/agent.*' )
+	_SSH_AGENT_SOCKETS=$( find "$TMPDIR" -type s -name agent.\* 2> /dev/null | grep '/ssh-.*/agent.*' )
 	_debug_print "$_SSH_AGENT_SOCKETS"
 }
 
 find_all_gpg_agent_sockets() {
-	_GPG_AGENT_SOCKETS=$( find /tmp/ -type s -name S.gpg-agent.ssh 2> /dev/null | grep '/tmp/gpg-.*/S.gpg-agent.ssh' )
+	_GPG_AGENT_SOCKETS=$( find "$TMPDIR" -type s -name S.gpg-agent.ssh 2> /dev/null | grep '/gpg-.*/S.gpg-agent.ssh' )
 	_debug_print "$_GPG_AGENT_SOCKETS"
 }
 
 find_all_gnome_keyring_agent_sockets() {
-	_GNOME_KEYRING_AGENT_SOCKETS=$( find /tmp/ -type s -name ssh 2> /dev/null | grep '/tmp/keyring-.*/ssh$' )
+	_GNOME_KEYRING_AGENT_SOCKETS=$( find "$TMPDIR" -type s -name ssh 2> /dev/null | grep '/keyring-.*/ssh$' )
 	_debug_print "$_GNOME_KEYRING_AGENT_SOCKETS"
 }
 
 find_all_osx_keychain_agent_sockets() {
-	[[ -n "$TMPDIR" ]] || TMPDIR=/tmp
-	_OSX_KEYCHAIN_AGENT_SOCKETS=$( find $TMPDIR/ -type s -regex '.*/ssh-.*/agent..*$' 2> /dev/null )
+	_OSX_KEYCHAIN_AGENT_SOCKETS=$( find "$TMPDIR" -type s -regex '.*/ssh-.*/agent..*$' 2> /dev/null )
 	_debug_print "$_OSX_KEYCHAIN_AGENT_SOCKETS"
 }
 


### PR DESCRIPTION
TMPDIR can be set on alternative platforms, such as [Termux](https://termux.com/). 