### PR TITLE
Fix PID extraction from filename on Termux

### DIFF
--- a/ssh-find-agent.sh
+++ b/ssh-find-agent.sh
@@ -202,7 +202,7 @@ set_ssh_agent_socket() {
 
 	# set agent pid
 	if [ -n "$SSH_AUTH_SOCK" ] ; then
-		export SSH_AGENT_PID=$(($(echo "$SSH_AUTH_SOCK" | cut -d. -f2) + 1))
+		export SSH_AGENT_PID=$(($(basename "$SSH_AUTH_SOCK" | cut -d. -f2) + 1))
 	fi
 
 	return 0


### PR DESCRIPTION
On Termux the PID extractions fails without this fix:

```
$ export _DEBUG=1; ssh_find_agent -c                                                                                                                          
/data/data/com.termux/files/usr/tmp/ssh-7qcLHwnOrV9Z/agent.5849


/data/data/com.termux/files/usr/tmp/ssh-7qcLHwnOrV9Z/agent.5849
0
0
/data/data/com.termux/files/usr/tmp/ssh-7qcLHwnOrV9Z/agent.5849:1 /data/data/com.termux/files/usr/tmp/ssh-7qcLHwnOrV9Z/agent.5849:1
SORTED: /data/data/com.termux/files/usr/tmp/ssh-7qcLHwnOrV9Z/agent.5849:1
export SSH_AUTH_SOCK=/data/data/com.termux/files/usr/tmp/ssh-7qcLHwnOrV9Z/agent.5849    #1)         
Choose (1-1)? 1
Setting export SSH_AUTH_SOCK=/data/data/com.termux/files/usr/tmp/ssh-7qcLHwnOrV9Z/agent.5849
set_ssh_agent_socket:33: division by zero
```

This is due to the fact that the path contains dots (the `com.termux` part in the example above).
Only using the filename and not the full path fixes this (hence the `basename` call).