### PR TITLE
add `-maxdepth 2` to limit depth for `find`

### DIFF
--- a/ssh-find-agent.sh
+++ b/ssh-find-agent.sh
@@ -39,22 +39,22 @@ _debug_print() {
 }
 
 find_all_ssh_agent_sockets() {
-  _SSH_AGENT_SOCKETS=$( find "$TMPDIR" -maxdepth 1 -type s -name agent.\* 2> /dev/null | grep '/ssh-.*/agent.*' )
+  _SSH_AGENT_SOCKETS=$( find "$TMPDIR" -maxdepth 2 -type s -name agent.\* 2> /dev/null | grep '/ssh-.*/agent.*' )
   _debug_print "$_SSH_AGENT_SOCKETS"
 }
 
 find_all_gpg_agent_sockets() {
-  _GPG_AGENT_SOCKETS=$( find "$TMPDIR" -maxdepth 1 -type s -name S.gpg-agent.ssh 2> /dev/null | grep '/gpg-.*/S.gpg-agent.ssh' )
+  _GPG_AGENT_SOCKETS=$( find "$TMPDIR" -maxdepth 2 -type s -name S.gpg-agent.ssh 2> /dev/null | grep '/gpg-.*/S.gpg-agent.ssh' )
   _debug_print "$_GPG_AGENT_SOCKETS"
 }
 
 find_all_gnome_keyring_agent_sockets() {
-  _GNOME_KEYRING_AGENT_SOCKETS=$( find "$TMPDIR" -maxdepth 1 -type s -name ssh 2> /dev/null | grep '/keyring-.*/ssh$' )
+  _GNOME_KEYRING_AGENT_SOCKETS=$( find "$TMPDIR" -maxdepth 2 -type s -name ssh 2> /dev/null | grep '/keyring-.*/ssh$' )
   _debug_print "$_GNOME_KEYRING_AGENT_SOCKETS"
 }
 
 find_all_osx_keychain_agent_sockets() {
-  _OSX_KEYCHAIN_AGENT_SOCKETS=$( find "$TMPDIR" -maxdepth 1 -type s -regex '.*/ssh-.*/agent..*$' 2> /dev/null )
+  _OSX_KEYCHAIN_AGENT_SOCKETS=$( find "$TMPDIR" -maxdepth 2 -type s -regex '.*/ssh-.*/agent..*$' 2> /dev/null )
   _debug_print "$_OSX_KEYCHAIN_AGENT_SOCKETS"
 }
 

--- a/ssh-find-agent.sh
+++ b/ssh-find-agent.sh
@@ -39,22 +39,22 @@ _debug_print() {
 }
 
 find_all_ssh_agent_sockets() {
-  _SSH_AGENT_SOCKETS=$( find "$TMPDIR" -type s -name agent.\* 2> /dev/null | grep '/ssh-.*/agent.*' )
+  _SSH_AGENT_SOCKETS=$( find "$TMPDIR" -maxdepth 1 -type s -name agent.\* 2> /dev/null | grep '/ssh-.*/agent.*' )
   _debug_print "$_SSH_AGENT_SOCKETS"
 }
 
 find_all_gpg_agent_sockets() {
-  _GPG_AGENT_SOCKETS=$( find "$TMPDIR" -type s -name S.gpg-agent.ssh 2> /dev/null | grep '/gpg-.*/S.gpg-agent.ssh' )
+  _GPG_AGENT_SOCKETS=$( find "$TMPDIR" -maxdepth 1 -type s -name S.gpg-agent.ssh 2> /dev/null | grep '/gpg-.*/S.gpg-agent.ssh' )
   _debug_print "$_GPG_AGENT_SOCKETS"
 }
 
 find_all_gnome_keyring_agent_sockets() {
-  _GNOME_KEYRING_AGENT_SOCKETS=$( find "$TMPDIR" -type s -name ssh 2> /dev/null | grep '/keyring-.*/ssh$' )
+  _GNOME_KEYRING_AGENT_SOCKETS=$( find "$TMPDIR" -maxdepth 1 -type s -name ssh 2> /dev/null | grep '/keyring-.*/ssh$' )
   _debug_print "$_GNOME_KEYRING_AGENT_SOCKETS"
 }
 
 find_all_osx_keychain_agent_sockets() {
-  _OSX_KEYCHAIN_AGENT_SOCKETS=$( find "$TMPDIR" -type s -regex '.*/ssh-.*/agent..*$' 2> /dev/null )
+  _OSX_KEYCHAIN_AGENT_SOCKETS=$( find "$TMPDIR" -maxdepth 1 -type s -regex '.*/ssh-.*/agent..*$' 2> /dev/null )
   _debug_print "$_OSX_KEYCHAIN_AGENT_SOCKETS"
 }
 


### PR DESCRIPTION
I think this PR can make the script faster when the `/tmp` has lots of directories and files.

Should fix (~~Not tested~~ works for me)

- #36

@see https://stackoverflow.com/a/4509648/1123955