### PR TITLE
Check availability of 'timeout' command

### DIFF
--- a/ssh-find-agent.sh
+++ b/ssh-find-agent.sh
@@ -31,6 +31,13 @@ _LIVE_AGENT_SOCK_LIST=()
 # temp dir. Defaults to /tmp
 TMPDIR="${TMPDIR:-/tmp}"
 
+if ! command -v 'timeout' &>/dev/null; then
+cat <<EOF >&2
+ssh-find-agent.sh: 'timeout' command could not be found:
+  Please install 'coreutils' via your system's package manager
+EOF
+fi
+
 _debug_print() {
   if [[ $_DEBUG -gt 0 ]]
   then


### PR DESCRIPTION
This PR prints an error message on systems that don't have `timeout` available, presumably because`coreutils` isn't available out of the box. Without a check like this in place, the user is required to debug the script to understand that `timeout` being unavailable is the culprit.